### PR TITLE
fix: double quotes not escaped correctly

### DIFF
--- a/syntaxes/ulp.tmLanguage.json
+++ b/syntaxes/ulp.tmLanguage.json
@@ -118,7 +118,7 @@
       "name": "storage.type.ulp"
     },
     "escapes": {
-      "match": "\\\\(?:a|b|f|n|r|t|v|\\|\\'|\\\"|[0-7]{1,3}|x[a-fA-F0-9]{1,2})",
+      "match": "\\\\(?:a|b|f|n|r|t|v|\\\\|\\'|\\\"|[0-7]{1,3}|x[a-fA-F0-9]{1,2})",
       "name": "constant.character.escape"
     },
     "block-delimiters": {


### PR DESCRIPTION
Fixes #1 

It was tedious but I guess I found the issue! 😰
The backslash was just not escaped enough inside the pattern used for matching escape sequences in strings.